### PR TITLE
Add default "." export to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "svelte-media-queries",
-    "version": "1.2.2",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "svelte-media-queries",
-            "version": "1.2.2",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "svelte2tsx": "^0.5.10"

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
     "type": "module",
     "dependencies": {
         "svelte2tsx": "^0.5.10"
+    },
+    "exports": {
+        ".": "./components/MediaQuery.svelte"
     }
 }
+

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "svelte2tsx": "^0.5.10"
     },
     "exports": {
-        ".": "./src/lib/components/MediaQuery.svelte"
+        ".": "./components/MediaQuery.svelte"
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "description": "A light and magical Svelte component for CSS media queries🐹",
     "version": "1.4.0",
     "license": "MIT",
-    "main": "./components/MediaQuery.svelte",
-    "svelte": "./components/MediaQuery.svelte",
+    "main": "./src/lib/components/MediaQuery.svelte",
+    "svelte": "./src/lib/components/MediaQuery.svelte",
     "repository": "https://github.com/fedorovvvv/svelte-media-queries",
     "author": "Nikita Fedorov <nikitafedorov7@yandex.ru>",
     "keywords": [
@@ -57,7 +57,7 @@
         "svelte2tsx": "^0.5.10"
     },
     "exports": {
-        ".": "./components/MediaQuery.svelte"
+        ".": "./src/lib/components/MediaQuery.svelte"
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "svelte2tsx": "^0.5.10"
     },
     "exports": {
-        ".": "./components/MediaQuery.svelte"
+        ".": "./src/lib/components/MediaQuery.svelte"
     }
 }
 


### PR DESCRIPTION
Upgrading to Vite 4.0 caused Vite to complain about a missing default export "." in package.json.  Added one and now working with Vite 4.0

Please merge if it makes sense to you.

