### PR TITLE
Support new Bundler option for TS module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     },
     "type": "module",
     "exports": {
-        ".": "./components/MediaQuery.svelte"
+        ".": {
+            "svelte": "./components/MediaQuery.svelte",
+            "types": "./components/MediaQuery.svelte.d.ts"
+        }
     }
 }


### PR DESCRIPTION
TS 5 [introduced](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#moduleresolution-bundler#moduleresolution-bundler) a new option for `moduleResolution` called `Bundler`, but it doesn't work with the way this library currently does exports.

This PR updates the `exports` in `package.json` to reflect the new `svelte-package` [defaults](https://kit.svelte.dev/docs/packaging#anatomy-of-a-package-json-exports).

This may be a breaking change for folks using `moduleResolution: 'Node'`