### PR TITLE
Add default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "type": "module",
     "exports": {
         ".": {
+            "default": "./components/MediaQuery.svelte",
             "svelte": "./components/MediaQuery.svelte",
             "types": "./components/MediaQuery.svelte.d.ts"
         }


### PR DESCRIPTION
The `svelte` field is a [legacy field](https://svelte.dev/docs/kit/packaging#Anatomy-of-a-package.json-svelte). With the latest version of vite and vitest, it didn't recognize the export when it was just `svelte`. Adding the default export got it to be recognized.

The error before this was this:
```
Error: Failed to resolve entry for package "svelte-media-queries". The package may have incorrect main/module/exports  specified in its package.json: No known conditions for "." specifier in "svelte-media-queries" package
```